### PR TITLE
Solved issue with DSP artefacts

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -68,7 +68,9 @@ void DRFilterAudioProcessor::updateFilterCoefficients() {
     {
         float lowPassCutoff = juce::jmap(cutoff, -100.0f, -FILTER_DEAD_ZONE, 20.0f, 20000.0f);
         auto lowPassCoefficients = juce::dsp::IIR::Coefficients<float>::makeLowPass(sampleRate, lowPassCutoff, Q);
+        
         filterProcessor.coefficients = lowPassCoefficients;
+        filterProcessor.reset();
     }
     else if (cutoff > FILTER_DEAD_ZONE)
     {
@@ -98,7 +100,9 @@ void DRFilterAudioProcessor::updateFilterCoefficients() {
         // // float skewedCutoff = std::pow(cutoff, skewFactor);
         // // float highPassCutoff = juce::jmap(outputValue, FILTER_DEAD_ZONE, 100.0f, 20.0f, 7000.0f);
         // auto highPassCoefficients = juce::dsp::IIR::Coefficients<float>::makeHighPass(sampleRate, highPassCutoff, Q);
+        
         filterProcessor.coefficients = highPassCoefficients;
+        filterProcessor.reset();
     }
     else
     {

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -76,8 +76,10 @@ private:
     //==============================================================================
     
     // Declare the state variable filter for stereo audio processing
-    juce::dsp::StateVariableTPTFilter<float> stateVariableTPTFilter;
-    juce::dsp::IIR::Filter<float> filterProcessor;
+    // juce::dsp::StateVariableTPTFilter<float> stateVariableTPTFilter;
+    // juce::dsp::IIR::Filter<float> filterProcessor;
+    
+    juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>> filterProcessor;
     // filterProcessor
 
     // Declare the saturation processor object

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -14,6 +14,10 @@
 // How many values on either side of zero the filter will stay disabled for
 #define FILTER_DEAD_ZONE 5.0f
 
+// Minimum and maximum Q values for the filter, starting at 0.707 (butterworth) up to spikey
+#define FILTER_Q_MIN 0.707f
+#define FILTER_Q_MAX 5.0f
+
 //==============================================================================
 /**
 */

--- a/TestSetup.filtergraph
+++ b/TestSetup.filtergraph
@@ -65,7 +65,7 @@
           uiopen_Normal="1">
     <PLUGIN name="AUAudioFilePlayer" format="AudioUnit" category="Generator"
             manufacturer="Apple" version="1.6.0" file="AudioUnit:Generators/augn,afpl,appl"
-            uniqueId="6163676e" isInstrument="0" fileTime="0" infoUpdateTime="187f2d9700c"
+            uniqueId="6163676e" isInstrument="0" fileTime="0" infoUpdateTime="187f726c8a4"
             numInputs="0" numOutputs="2" isShell="0" hasARAExtension="0"
             uid="6163676e"/>
     <STATE>875.hAGaoMGcv.C1AHv.DTfAGfPBJr.IkXxIpvUag4VclE1XzUmbkIGUjEFcg8EDarVPUAkbkMWYzAUYxMWZyQWYtQ2TzEFcksTY4c0b0IFc4AWYWYWYxMWZu4FUzkGbk8EDOXVZrUVKxUlYkIWYtMVYyQkag0VYRDFbvwFPhxfFR2fCO.AVFkFak4TXsU1URU1Yo8lay8EDf8RUyUlby8RXyg1aqYVYx4VXtQVY58RS0MWZi8RPhwVYz8lauT0bkIGHLklXxElb48xTg0FbrU1bujTav8lbzUFYuPkUD8UNv7kbkMWXsAGakQ1WhIWYgs1WiUmXtbWX1EZDTKwDTTgEWXQFdIUYmk1atQzakMGSu8FbZIUYmk1atQTXzE1WP.QRyMUYrU1XzUFYRU1Yo8laZIUYmk1at4TXsUVBOAAb...........PEgC...F...................13FED..........PB.........TMURLg....P....................................................f............a4....9b.kfVNU1cfHUYmk1atMcCNrAGcXgWIM2TkwVYiQWYjYTZrU1WP31KUMWYxM2KgMGZuslYkImag4FYko2KD81ctw1agQ1bu7larkWavMiKz8FHs.xRk4lZoABRo4VXfzBH2XiLfrUQMUjTAwDQvDCMC0UKtQTZJQSY0oFaAEUKxTiMq0RL1TCM1XSLy.CM4jyMtzFbyDpGTKwDTTwGfXgHH7DDvA..........f637A..X...................XiaTP..........PUUUUUUUUUUUUUUUUUUUUUA....TUUUUE..........................................B...........XL1...3yATBZ4TY2AhTkcVZu4VBRDlYvwFD.HQX0claRiRJOvgUFkFakARLVYTZrUFHxfUUtQWZzwVYjA.B.jA.l.vJ.jD.QAPV.3E.vAPc.nG.6Afe.LH.LB.k.bO.4Gf.ADQ.bDvKAnS.6DfqA7Z.5FPvA.s.AIvPBvj.MI.vBDr.LKPyBHs.TKP1B3s.kK.6........BD..........q...................BTO</STATE>
@@ -76,11 +76,11 @@
       </OUTPUTS>
     </LAYOUT>
   </FILTER>
-  <FILTER uid="7" x="0.40625" y="0.4826923076923077" useARA="0" uiLastX_Normal="203"
-          uiLastY_Normal="239" uiopen_Normal="0">
+  <FILTER uid="7" x="0.40625" y="0.4826923076923077" useARA="0" uiLastX_Normal="561"
+          uiLastY_Normal="256" uiopen_Normal="1">
     <PLUGIN name="DR Filter" format="VST3" category="Fx|Filter" manufacturer="Side Effects"
             version="1.0.0" file="/Users/ashokfernandez/Software/DR Filter/Builds/MacOSX/build/Debug/DR Filter.vst3"
-            uniqueId="ac02e07e" isInstrument="0" fileTime="187f140c89f" infoUpdateTime="187f2d9700d"
+            uniqueId="ac02e07e" isInstrument="0" fileTime="187f140c89f" infoUpdateTime="187f726c8a5"
             numInputs="2" numOutputs="2" isShell="0" hasARAExtension="0"
             uid="ad72036d"/>
     <STATE>191.VMjLgXK....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOVMEUy.Ea0cVZtMEcgQWY9vSRC8Vav8lak4Fc9XCLt3hKt3hKt3hKt3hYRUUSTEETIckVwTjQisVTTgkdEYjKAQjYPQSPWgUdMcjKAQjct3hdA4hKt3hKt3hKtnTUv.UQAslXuk0UXoWUFE0YQcEV77RRC8Vav8lak4Fc9vyKVMEUy.Ea0cVZtMEcgQWY9..</STATE>


### PR DESCRIPTION
Got rid of all the junk code from ChatGPT and used more of the inbuild JUCE structures such as ProcessorDuplicator to get the audio processing cleanly for the filter. 

There are still jitters when the parameters change, and the ranges need to be mapped appropriately. 