### PR TITLE
State variable filter

### DIFF
--- a/Source/.vscode/c_cpp_properties.json
+++ b/Source/.vscode/c_cpp_properties.json
@@ -1,0 +1,20 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/Users/ashokfernandez/Software/JUCE/**"
+            ],
+            "defines": [],
+            "macFrameworkPath": [
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "macos-clang-arm64"
+        }
+    ],
+    "version": 4
+}

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -18,6 +18,17 @@
 #define FILTER_Q_MIN 0.707f
 #define FILTER_Q_MAX 5.0f
 
+// Skew factor for non-linear mapping of parameters 
+#define CUTOFF_SKEW_FACTOR 0.99f
+
+// Max and min hearing frequencies
+#define MAX_FREQ 20000.0f
+#define MIN_FREQ 20.0f
+
+// Time factor used to smooth parameter changes
+#define SMOOTHING_TIME_SECONDS 0.05f
+#define NORMALISED_INTERNAL 0.1f
+
 //==============================================================================
 /**
 */
@@ -72,34 +83,21 @@ public:
     
 
 private:
-    
-    void updateFilterCoefficients();
-
+    // Parameter setup
     static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
 
-    //==============================================================================
-    
-    // Declare the state variable filter for stereo audio processing
-    // juce::dsp::StateVariableTPTFilter<float> stateVariableTPTFilter;
-    // juce::dsp::IIR::Filter<float> filterProcessor;
-    
+    // Signal chain objects
+    juce::dsp::ProcessSpec spec;
     juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>> filterProcessor;
-    // filterProcessor
+    void updateFrequency();
+    void updateResonance();
+    void updateFilterCoefficients();
 
-    // Declare the saturation processor object
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> lowPassCutoffSmoothed, highPassCutoffSmoothed, resonanceSmoothed;
+    juce::NormalisableRange<float> lowPassCutoffRange, highPassCutoffRange;
+    
+    // Todo set this up wiht a processor duplicator
     CustomWaveShaper saturationProcessor;
 
-    // Declare the ProcessSpec object
-    juce::dsp::ProcessSpec spec;
-
-  
-
-    
-
-    //==============================================================================
-
-
-    
-    //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (DRFilterAudioProcessor)
 };

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -16,7 +16,7 @@
 
 // Minimum and maximum Q values for the filter, starting at 0.707 (butterworth) up to spikey
 #define FILTER_Q_MIN 0.707f
-#define FILTER_Q_MAX 5.0f
+#define FILTER_Q_MAX 8.0f
 
 // Skew factor for non-linear mapping of parameters 
 #define HIGHPASS_CUTOFF_SKEW_FACTOR 0.5f
@@ -90,13 +90,33 @@ private:
 
     // Signal chain objects
     juce::dsp::ProcessSpec spec;
-    juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>> filterProcessor;
+    
+    // juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>> filterProcessor;
+    
+    // juce::dsp::ProcessorDuplicator<juce::dsp::StateVariableTPTFilter<float>, juce::dsp::StateVariableFilter::Parameters<float>> filterProcessor;
+    juce::dsp::StateVariableTPTFilter<float> filterProcessor;
+    
+    // juce::dsp::ProcessorDuplicator<juce::dsp::LadderFilter<float>, juce::dsp::LadderFilter<float>::Parameters> filterProcessor;
+    // juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>> lowPassFilterProcessor, highPassFilterProcessor;
+    // juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>> filterProcessor;
+
+    
     void updateFrequency();
     void updateResonance();
-    void updateFilterCoefficients();
+    void updateFilterType();
+    // void updateFilter();
 
-    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> lowPassCutoffSmoothed, highPassCutoffSmoothed, resonanceSmoothed;
-    juce::NormalisableRange<float> lowPassCutoffRange, highPassCutoffRange;
+//    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> lowPassCutoffSmoothed, highPassCutoffSmoothed, resonanceSmoothed;
+//    juce::NormalisableRange<float> lowPassCutoffRange, highPassCutoffRange;
+
+    enum FilterType
+    {
+        LowPass,
+        HighPass, 
+        Disabled
+    };
+
+    FilterType currentFilterType = FilterType::Disabled;
     
     // Todo set this up wiht a processor duplicator
     CustomWaveShaper saturationProcessor;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -19,15 +19,17 @@
 #define FILTER_Q_MAX 5.0f
 
 // Skew factor for non-linear mapping of parameters 
-#define CUTOFF_SKEW_FACTOR 0.99f
+#define HIGHPASS_CUTOFF_SKEW_FACTOR 0.5f
+#define LOWPASS_CUTOFF_SKEW_FACTOR 1.5f
+
 
 // Max and min hearing frequencies
 #define MAX_FREQ 20000.0f
 #define MIN_FREQ 20.0f
 
 // Time factor used to smooth parameter changes
-#define SMOOTHING_TIME_SECONDS 0.05f
-#define NORMALISED_INTERNAL 0.1f
+#define SMOOTHING_TIME_SECONDS 0.5f
+// #define NORMALISED_INTERNAL 0.1f
 
 //==============================================================================
 /**

--- a/TestSetup.filtergraph
+++ b/TestSetup.filtergraph
@@ -65,7 +65,7 @@
           uiopen_Normal="1">
     <PLUGIN name="AUAudioFilePlayer" format="AudioUnit" category="Generator"
             manufacturer="Apple" version="1.6.0" file="AudioUnit:Generators/augn,afpl,appl"
-            uniqueId="6163676e" isInstrument="0" fileTime="0" infoUpdateTime="187f726c8a4"
+            uniqueId="6163676e" isInstrument="0" fileTime="0" infoUpdateTime="187f7c407e7"
             numInputs="0" numOutputs="2" isShell="0" hasARAExtension="0"
             uid="6163676e"/>
     <STATE>875.hAGaoMGcv.C1AHv.DTfAGfPBJr.IkXxIpvUag4VclE1XzUmbkIGUjEFcg8EDarVPUAkbkMWYzAUYxMWZyQWYtQ2TzEFcksTY4c0b0IFc4AWYWYWYxMWZu4FUzkGbk8EDOXVZrUVKxUlYkIWYtMVYyQkag0VYRDFbvwFPhxfFR2fCO.AVFkFak4TXsU1URU1Yo8lay8EDf8RUyUlby8RXyg1aqYVYx4VXtQVY58RS0MWZi8RPhwVYz8lauT0bkIGHLklXxElb48xTg0FbrU1bujTav8lbzUFYuPkUD8UNv7kbkMWXsAGakQ1WhIWYgs1WiUmXtbWX1EZDTKwDTTgEWXQFdIUYmk1atQzakMGSu8FbZIUYmk1atQTXzE1WP.QRyMUYrU1XzUFYRU1Yo8laZIUYmk1at4TXsUVBOAAb...........PEgC...F...................13FED..........PB.........TMURLg....P....................................................f............a4....9b.kfVNU1cfHUYmk1atMcCNrAGcXgWIM2TkwVYiQWYjYTZrU1WP31KUMWYxM2KgMGZuslYkImag4FYko2KD81ctw1agQ1bu7larkWavMiKz8FHs.xRk4lZoABRo4VXfzBH2XiLfrUQMUjTAwDQvDCMC0UKtQTZJQSY0oFaAEUKxTiMq0RL1TCM1XSLy.CM4jyMtzFbyDpGTKwDTTwGfXgHH7DDvA..........f637A..X...................XiaTP..........PUUUUUUUUUUUUUUUUUUUUUA....TUUUUE..........................................B...........XL1...3yATBZ4TY2AhTkcVZu4VBRDlYvwFD.HQX0claRiRJOvgUFkFakARLVYTZrUFHxfUUtQWZzwVYjA.B.jA.l.vJ.jD.QAPV.3E.vAPc.nG.6Afe.LH.LB.k.bO.4Gf.ADQ.bDvKAnS.6DfqA7Z.5FPvA.s.AIvPBvj.MI.vBDr.LKPyBHs.TKP1B3s.kK.6........BD..........q...................BTO</STATE>
@@ -80,7 +80,7 @@
           uiLastY_Normal="256" uiopen_Normal="1">
     <PLUGIN name="DR Filter" format="VST3" category="Fx|Filter" manufacturer="Side Effects"
             version="1.0.0" file="/Users/ashokfernandez/Software/DR Filter/Builds/MacOSX/build/Debug/DR Filter.vst3"
-            uniqueId="ac02e07e" isInstrument="0" fileTime="187f140c89f" infoUpdateTime="187f726c8a5"
+            uniqueId="ac02e07e" isInstrument="0" fileTime="187f7a5390d" infoUpdateTime="187f7c407e8"
             numInputs="2" numOutputs="2" isShell="0" hasARAExtension="0"
             uid="ad72036d"/>
     <STATE>191.VMjLgXK....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOVMEUy.Ea0cVZtMEcgQWY9vSRC8Vav8lak4Fc9XCLt3hKt3hKt3hKt3hYRUUSTEETIckVwTjQisVTTgkdEYjKAQjYPQSPWgUdMcjKAQjct3hdA4hKt3hKt3hKtnTUv.UQAslXuk0UXoWUFE0YQcEV77RRC8Vav8lak4Fc9vyKVMEUy.Ea0cVZtMEcgQWY9..</STATE>


### PR DESCRIPTION
The filter cutoff can now be modulated without any artefacts. The IIR filters I was using previous crackle and pop if you update their coefficients, the new implementation with the state variable filter fixes this. 

Still todo: mapping the cutoff knob to the appropriate cutoff frequency